### PR TITLE
FUM-3033-rule-priorities

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,20 +10,20 @@ It's designed to propose the following rules:
 
 |Priority|Rule Name|Notes|
 |----------|----------|------|
-|0 | whitelisted_ips_v4| Automatically download and whitelist bots IPV4s (see variables) and whitelist any list of IPV4 ranges|
-|1 | whitelisted_ips_v6| Automatically download and whitelist bots IPV6s (see variables) and whitelist any list of IPV6 ranges|
-|2 | rate_limit_everything_apart_from_CH| This rule is meant to be a failsafe switch in case of attack. Change "count" to "block" in the console if you are under attack and want to rate limit to a low number of requests every country except Switzerland |
-|3 | count_requests_from_ch| |
-|4-9 | | Free priority range for additional rules |
-|10-19 | AWS Managed rule groups | Each group could contain multiple labels, please refer to the [doc](https://docs.aws.amazon.com/waf/latest/developerguide/aws-managed-rule-groups-list.html)|
-|20-29 | AWS managed rule labels| For a list of labels is possible to define an action: block, captcha or challenge. In all cases is possible to define a rate limit or directly apply the action |
-|30-49 | country_rates| Geographical rules|
-|50 | everybody_else_limit| The blocking limit for all country_codes which are not covered by the country_rates rule|
-|60-69 | AWS managed rule labels| Additional priority range reserved for AWS Managed rule labels |
-|70 | limit_search_requests_by_countries| |
-|71-89 | block_uri_path_string| |
-|90-109 | block_articles| |
-|110-129 | block_regex_pattern| |
+|0 | limit_search_requests_by_countries | |
+|1-9 | block_uri_path_string | |
+|10-19 | block_articles | |
+|20-29 | block_regex_pattern | |
+|30-39 free | Free priority range for additional rules |
+|40 | whitelisted_ips_v4 | Automatically download and whitelist bots IPV4s (see variables) and whitelist any list of IPV4 ranges|
+|41 | whitelisted_ips_v6 | Automatically download and whitelist bots IPV6s (see variables) and whitelist any list of IPV6 ranges|
+|42 | Rate_limit_everything_apart_from_CH | This rule is meant to be a failsafe switch in case of attack. Change "count" to "block" in the console if you are under attack and want to rate limit to a low number of requests every country except Switzerland |
+|43 | count_requests_from_ch | 
+|44-49 | free | Free priority range for additional rules |
+|50-59 | AWS Managed rule groups | Each group could contain multiple labels, please refer to the [doc](https://docs.aws.amazon.com/waf/latest/developerguide/aws-managed-rule-groups-list.html)|
+|60-69 | AWS managed rule labels rate limit | For a list of labels is possible to define an action: block, captcha or challenge. In all cases is possible to define a rate limit or directly apply the action |
+|70-79 | country_rates | Geographical rules|
+|80 | everybody_else_limit | The blocking limit for all country_codes which are not covered by the country_rates rule|
 
 ## Waf logging
 

--- a/examples/complete/main.tf
+++ b/examples/complete/main.tf
@@ -37,24 +37,24 @@ module "waf" {
   aws_managed_rule_groups = [
     {
       name     = "AWSManagedRulesAnonymousIpList" # Full list of labels from this group: https://docs.aws.amazon.com/waf/latest/developerguide/aws-managed-rule-groups-ip-rep.html
-      priority = 10
+      priority = 50
     },
     {
       name     = "AWSManagedRulesAmazonIpReputationList" # Full list of labels from this group: https://docs.aws.amazon.com/waf/latest/developerguide/aws-managed-rule-groups-ip-rep.html
-      priority = 11
+      priority = 59
     }
   ]
   aws_managed_rule_labels = [
     {
       name     = "aws_managed_rule_low_limit"
       labels   = ["awswaf:managed:aws:anonymous-ip-list:AnonymousIPList", "awswaf:managed:aws:amazon-ip-list:AWSManagedIPReputationList", "awswaf:managed:aws:amazon-ip-list:AWSManagedReconnaissanceList", "awswaf:managed:aws:amazon-ip-list:AWSManagedIPDDoSList"]
-      priority = 20
+      priority = 60
     },
     {
       name     = "aws_managed_rule_high_limit"
       labels   = ["awswaf:managed:aws:anonymous-ip-list:HostingProviderIPList"]
       limit    = 750
-      priority = 21
+      priority = 61
     },
   ]
   count_requests_from_ch = false
@@ -63,19 +63,19 @@ module "waf" {
       name          = "Group_1-CH"
       limit         = 50000
       country_codes = ["CH"]
-      priority      = 30
+      priority      = 70
     },
     {
       name          = "Group_2-DE_AT_FR"
       limit         = 4000
       country_codes = ["AT", "FR", "DE"]
-      priority      = 31
+      priority      = 71
     },
     {
       name          = "Very_slow"
       limit         = 100
       country_codes = ["AR", "BD", "BR", "KH", "CN", "CO", "EC", "IN", "ID", "MX", "NP", "PK", "RU", "SG", "TR", "UA", "AE", "ZM", "VN"]
-      priority      = 35
+      priority      = 72
     }
   ]
   everybody_else_limit = 0

--- a/variables.tf
+++ b/variables.tf
@@ -74,7 +74,7 @@ variable "k6_ip_ranges_url" {
 
 variable "whitelisted_ips_v4" {
   default     = []
-  description = "List of enterprise IP ranges to be whitelisted. Set to empty list to disable the whitelisting"
+  description = "List of IP ranges to be whitelisted. Set to empty list to disable the whitelisting"
   type        = list(string)
   validation {
     condition = alltrue([
@@ -86,7 +86,7 @@ variable "whitelisted_ips_v4" {
 
 variable "whitelisted_ips_v6" {
   default     = []
-  description = "The IPv6 to allow"
+  description = "List of IP ranges to be whitelisted. Set to empty list to disable the whitelisting"
   type        = list(string)
   validation {
     # Not the "real" regexp for ipv6. The right one has around 1000 characters...
@@ -106,15 +106,15 @@ variable "aws_managed_rule_groups" {
   default = [
     {
       name     = "AWSManagedRulesAnonymousIpList" # Full list of labels from this group: https://docs.aws.amazon.com/waf/latest/developerguide/aws-managed-rule-groups-ip-rep.html
-      priority = 10
+      priority = 50
     },
     {
       name     = "AWSManagedRulesAmazonIpReputationList" # Full list of labels from this group: https://docs.aws.amazon.com/waf/latest/developerguide/aws-managed-rule-groups-ip-rep.html
-      priority = 11
+      priority = 51
     }
   ]
   validation {
-    condition     = alltrue([for group in var.aws_managed_rule_groups : group.priority >= 10 && group.priority < 20])
+    condition     = alltrue([for group in var.aws_managed_rule_groups : group.priority >= 50 && group.priority < 60])
     error_message = "var.aws_managed_rule_groups.priority must be between 10 and 19. var.aws_managed_rule_groups.override_group_action should be either count or block"
   }
 }
@@ -134,18 +134,18 @@ variable "aws_managed_rule_labels" {
     {
       name     = "aws_managed_rule_low_limit"
       labels   = ["awswaf:managed:aws:anonymous-ip-list:AnonymousIPList", "awswaf:managed:aws:amazon-ip-list:AWSManagedIPReputationList", "awswaf:managed:aws:amazon-ip-list:AWSManagedReconnaissanceList", "awswaf:managed:aws:amazon-ip-list:AWSManagedIPDDoSList"]
-      priority = 20
+      priority = 60
     },
     {
       name     = "aws_managed_rule_high_limit"
       labels   = ["awswaf:managed:aws:anonymous-ip-list:HostingProviderIPList"]
       limit    = 750
-      priority = 21
+      priority = 61
     },
   ]
   validation {
-    condition     = alltrue([for rule in var.aws_managed_rule_labels : ((rule.priority >= 20 && rule.priority < 30) || (rule.priority >= 60 && rule.priority < 70) && contains(["block", "captcha", "challenge"], rule.action))])
-    error_message = "var.aws_managed_rule_labels.priority must be between 20 and 29 or between 60 and 69. var.aws_managed_rule_labels.action must be either block, captcha or challenge"
+    condition     = alltrue([for rule in var.aws_managed_rule_labels : ((rule.priority >= 60 && rule.priority < 70) || (rule.priority > 80) && contains(["block", "captcha", "challenge"], rule.action))])
+    error_message = "var.aws_managed_rule_labels.priority must be between 60 and 69 or greater than 80. var.aws_managed_rule_labels.action must be either block, captcha or challenge"
   }
 }
 
@@ -184,8 +184,8 @@ variable "country_rates" {
   #   }
   # ]
   validation {
-    condition     = alltrue([for uri in var.country_rates : uri.priority >= 30 && uri.priority < 50])
-    error_message = "var.country_rates.priority must be between 20 and 49"
+    condition     = alltrue([for uri in var.country_rates : uri.priority >= 70 && uri.priority < 80])
+    error_message = "var.country_rates.priority must be between 70 and 80"
   }
 }
 
@@ -212,13 +212,13 @@ variable "block_uri_path_string" {
   description = "Allow to block specific strings, defining the positional constraint of the string."
   type = list(object({
     name                  = string
-    priority              = optional(number, 71)
+    priority              = optional(number, 1)
     positional_constraint = optional(string, "EXACTLY")
     search_string         = string
   }))
   validation {
-    condition     = alltrue([for uri in var.block_uri_path_string : uri.priority >= 71 && uri.priority < 90 && contains(["EXACTLY", "STARTS_WITH", "ENDS_WITH", "CONTAINS", "CONTAINS_WORD"], uri.positional_constraint)])
-    error_message = "var.block_uri_path_string.priority must be between 71 and 89"
+    condition     = alltrue([for uri in var.block_uri_path_string : uri.priority >= 1 && uri.priority < 9 && contains(["EXACTLY", "STARTS_WITH", "ENDS_WITH", "CONTAINS", "CONTAINS_WORD"], uri.positional_constraint)])
+    error_message = "var.block_uri_path_string.priority must be between 1 and 9"
   }
 }
 
@@ -250,8 +250,8 @@ variable "block_articles" {
   #   ...
   # ]
   validation {
-    condition     = alltrue([for uri in var.block_articles : uri.priority >= 90 && uri.priority < 110])
-    error_message = "var.block_articles.priority must be between 90 and 109"
+    condition     = alltrue([for uri in var.block_articles : uri.priority >= 10 && uri.priority < 19])
+    error_message = "var.block_articles.priority must be between 10 and 19"
   }
 }
 
@@ -274,8 +274,8 @@ variable "block_regex_pattern" {
   #   }
   # }
   validation {
-    condition     = alltrue([for uri in var.block_regex_pattern : uri.priority >= 110 && uri.priority < 130])
-    error_message = "var.block_regex_pattern.priority must be between 110 and 129"
+    condition     = alltrue([for uri in var.block_regex_pattern : uri.priority >= 20 && uri.priority < 30])
+    error_message = "var.block_regex_pattern.priority must be between 20 and 29"
   }
 }
 

--- a/waf.tf
+++ b/waf.tf
@@ -1,18 +1,19 @@
 ## Priorities:
-# 0: whitelisted_ips_v4
-# 1: whitelisted_ips_v6
-# 2: Rate_limit_everything_apart_from_CH
-# 3: count_requests_from_ch
-# 4-9: free
-# 10-19: AWS Managed rule groups (these are the one that only counts and labels requests
-# 20-29: AWS managed rule labels rate limit
-# 30-49: country_rates
-# 50: everybody_else_limit
+# 0: limit_search_requests_by_countries
+# 1-9: block_uri_path_string
+# 10-19: block_articles
+# 20-29: block_regex_pattern
+# 30-39 free
+# 40: whitelisted_ips_v4
+# 41: whitelisted_ips_v6
+# 42: Rate_limit_everything_apart_from_CH
+# 43: count_requests_from_ch
+# 44-49: free
+# 50-59: AWS Managed rule groups (these are the one that only counts and labels requests
 # 60-69: AWS managed rule labels rate limit
-# 70: limit_search_requests_by_countries
-# 71-89: block_uri_path_string
-# 90-109: block_articles
-# 110-129: block_regex_pattern
+# 70-79: country_rates
+# 80: everybody_else_limit
+
 
 locals {
   everybody_else_exclude_country_codes = distinct(flatten([ # find all the country_codes mentioned in our rules
@@ -88,7 +89,7 @@ resource "aws_wafv2_web_acl" "waf" {
     for_each = length(local.group_whitelist_ipv4) == 0 ? [] : [1]
     content {
       name     = "whitelisted_ips_v4"
-      priority = 0
+      priority = 40
       action {
         allow {}
       }
@@ -117,7 +118,7 @@ resource "aws_wafv2_web_acl" "waf" {
     for_each = length(local.group_whitelist_ipv6) == 0 ? [] : [1]
     content {
       name     = "whitelisted_ips_v6"
-      priority = 1
+      priority = 41
       action {
         allow {}
       }
@@ -147,7 +148,7 @@ resource "aws_wafv2_web_acl" "waf" {
   # rate limit to a low number of requests every country except Switzerland
   rule {
     name     = "rate_limit_everything_apart_from_CH"
-    priority = 2
+    priority = 42
     action {
       count {}
     }
@@ -184,7 +185,7 @@ resource "aws_wafv2_web_acl" "waf" {
     for_each = var.count_requests_from_ch ? [1] : []
     content {
       name     = "Switzerland"
-      priority = 3
+      priority = 43
       action {
         count {}
       }
@@ -385,7 +386,7 @@ resource "aws_wafv2_web_acl" "waf" {
     for_each = var.everybody_else_limit == 0 ? [] : [1]
     content {
       name     = "Everybody_else"
-      priority = 50
+      priority = 80
       action {
         block {
           custom_response {
@@ -429,7 +430,7 @@ resource "aws_wafv2_web_acl" "waf" {
     for_each = length(var.limit_search_requests_by_countries.country_codes) > 0 ? [1] : []
     content {
       name     = "limit_search_requests_by_countries"
-      priority = 70
+      priority = 0
       action {
         block {
           custom_response {

--- a/waf.tf
+++ b/waf.tf
@@ -9,7 +9,7 @@
 # 42: Rate_limit_everything_apart_from_CH
 # 43: count_requests_from_ch
 # 44-49: free
-# 50-59: AWS Managed rule groups (these are the one that only counts and labels requests
+# 50-59: AWS Managed rule groups (these are the ones that only count and label requests)
 # 60-69: AWS managed rule labels rate limit
 # 70-79: country_rates
 # 80: everybody_else_limit


### PR DESCRIPTION
New priorities:
```
# 0: limit_search_requests_by_countries
# 1-9: block_uri_path_string
# 10-19: block_articles
# 20-29: block_regex_pattern
# 30-39 free
# 40: whitelisted_ips_v4
# 41: whitelisted_ips_v6
# 42: Rate_limit_everything_apart_from_CH
# 43: count_requests_from_ch
# 44-49: free
# 50-59: AWS Managed rule groups (these are the one that only counts and labels requests
# 60-69: AWS managed rule labels rate limit
# 70-79: country_rates
# 80: everybody_else_limit
```