### PR TITLE
fum-3101-rule-group-for-aws-managed-rule-labels

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -1,0 +1,16 @@
+name: Release on tag
+
+# Tag should have the same version as in the `setup.py`
+on:
+  push:
+    tags:
+      - "v*.*.*"
+
+permissions:
+  contents: write
+
+jobs:
+  release:
+    uses: tx-pts-dai/github-workflows/.github/workflows/gh-release.yaml@v0.11.0
+    with:
+      tag: ${{ github.ref_name }}

--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ It's designed to propose the following rules:
 |43 | count_requests_from_ch | 
 |44-49 | free | Free priority range for additional rules |
 |50-59 | AWS Managed rule groups | Each group could contain multiple labels, please refer to the [doc](https://docs.aws.amazon.com/waf/latest/developerguide/aws-managed-rule-groups-list.html)|
-|60-69 | AWS managed rule labels rate limit | For a list of labels is possible to define an action: block, captcha or challenge. In all cases is possible to define a rate limit or directly apply the action |
+|60 | AWS managed rule labels rate limit | For a list of labels is possible to define an action: block, captcha or challenge. In all cases is possible to define a rate limit or directly apply the action |
 |70-79 | country_rates | Geographical rules|
 |80 | everybody_else_limit | The blocking limit for all country_codes which are not covered by the country_rates rule|
 

--- a/variables.tf
+++ b/variables.tf
@@ -144,8 +144,12 @@ variable "aws_managed_rule_labels" {
     },
   ]
   validation {
-    condition     = alltrue([for rule in var.aws_managed_rule_labels : ((rule.priority >= 60 && rule.priority < 70) || (rule.priority > 80) && contains(["block", "captcha", "challenge"], rule.action))])
-    error_message = "var.aws_managed_rule_labels.priority must be between 60 and 69 or greater than 80. var.aws_managed_rule_labels.action must be either block, captcha or challenge"
+    condition     = length(var.aws_managed_rule_labels) <= 4
+    error_message = "var.aws_managed_rule_labels can have a max length of 4."
+  }
+  validation {
+    condition     = alltrue([for rule in var.aws_managed_rule_labels : (rule.priority >= 60 && rule.priority < 64) && contains(["block", "captcha", "challenge"], rule.action)])
+    error_message = "var.aws_managed_rule_labels.priority must be between 60 and 63. var.aws_managed_rule_labels.action must be either block, captcha or challenge"
   }
 }
 


### PR DESCRIPTION
Actual proposal to avoid hitting the ACL rate-based rules limit: move all the aws rate-based rules related to aws managed rule groups labels into one single waf rule group. 
PRO: the grouping makes sense and we reduce by 1 the total number of rate-based rules in the web acl (not much but exacly what we currently need for the granularity we want)
CONS: we will have a fixe max of 4 rate-based rules for aws managed rule groups labels (not really that bad as currently we are setting only two)