### PR TITLE
fix: terraform error if enable_logging is false

### DIFF
--- a/logs.tf
+++ b/logs.tf
@@ -1,6 +1,8 @@
 data "aws_s3_bucket" "log_bucket" {
+  count  = var.enable_logging ? 1 : 0
   bucket = var.alternative_logs_bucket_name
 }
+
 resource "aws_athena_workgroup" "waf" {
   count         = var.deploy_logs ? 1 : 0
   name          = "waf-logs-${var.waf_name}"
@@ -115,6 +117,6 @@ resource "aws_s3_bucket_lifecycle_configuration" "logs" {
 
 resource "aws_wafv2_web_acl_logging_configuration" "logs" {
   count                   = var.enable_logging ? 1 : 0
-  log_destination_configs = [var.deploy_logs ? aws_s3_bucket.logs[0].arn : data.aws_s3_bucket.log_bucket.arn]
+  log_destination_configs = [var.deploy_logs ? aws_s3_bucket.logs[0].arn : data.aws_s3_bucket.log_bucket[0].arn]
   resource_arn            = aws_wafv2_web_acl.waf.arn
 }


### PR DESCRIPTION
V5.0.0 has a terraform issue if `enable_logging` is false:
╷
│ Error: Missing required argument
│ 
│   with module.feed_regional_waf.data.aws_s3_bucket.log_bucket,
│   on .terraform/modules/feed_regional_waf/logs.tf line 2, in data "aws_s3_bucket" "log_bucket":
│    2:   bucket = var.alternative_logs_bucket_name
│ 
│ The argument "bucket" is required, but no definition was found.
╵
This PR fix the issue