### PR TITLE
fix: bug when country_count_rules is empty

### DIFF
--- a/waf.tf
+++ b/waf.tf
@@ -561,6 +561,7 @@ resource "aws_wafv2_web_acl" "waf" {
       }
     }
   }
+
   rule {
     name     = "${var.waf_name}_aws_managed_rule_labels"
     priority = 60
@@ -602,8 +603,9 @@ resource "aws_wafv2_web_acl" "waf" {
       }
     }
   }
+
   dynamic "rule" {
-    for_each = length(var.country_count_rules) > 0 ? [1] : [0]
+    for_each = length(var.country_count_rules) > 0 ? [1] : []
     content {
       name     = "${var.waf_name}_country_count_rules"
       priority = 90
@@ -612,7 +614,7 @@ resource "aws_wafv2_web_acl" "waf" {
       }
       statement {
         rule_group_reference_statement {
-          arn = try(aws_wafv2_rule_group.country_count_rules[0].arn, "")
+          arn = aws_wafv2_rule_group.country_count_rules[0].arn
         }
       }
       visibility_config {


### PR DESCRIPTION
To fix the error:
```
╷
│ Error: creating WAFv2 WebACL (rba_test_rba_test): operation error WAFV2: CreateWebACL, https response error StatusCode: 400, RequestID: e0784c09-a4c8-4964-9269-07ff0c5d2899, WAFInvalidParameterException: Error reason: The ARN isn't valid. A valid ARN begins with arn: and includes other information separated by colons or slashes., field: RESOURCE_ARN, parameter: 
│ 
│   with module.waf.aws_wafv2_web_acl.waf,
│   on ../../terraform-aws-waf/waf.tf line 81, in resource "aws_wafv2_web_acl" "waf":
│   81: resource "aws_wafv2_web_acl" "waf" {
│ 
```
on terraform apply

To merge with commit message: "fix: ..."