### PR TITLE
feat!: remove AWS Shield Advanced integration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## [8.0.0]
 
-This version introduces breaking changes to several variables to allow configurable WAF ACL priorities, removes built-in bot IP fetching in favour of the `ip_list_fetcher` submodule, and adds AWS Shield Advanced integration. **All users must update their Terraform configurations** when upgrading to this version.
+This version introduces breaking changes to several variables to allow configurable WAF ACL priorities, removes built-in bot IP fetching in favour of the `ip_list_fetcher` submodule. **All users must update their Terraform configurations** when upgrading to this version.
 
 ### Breaking changes
 
@@ -82,25 +82,6 @@ ip_whitelisting = {
 ```
 
 ### New features
-
-#### AWS Shield Advanced integration (`shield_mitigation`)
-
-The module can now reference the AWS Shield Advanced automatic mitigation rule group via `var.shield_mitigation`. Key points:
-
-- Shield creates **one rule group per WAF ACL**, regardless of how many resources share that ACL or have automatic mitigation enabled.
-- `aws_shield_application_layer_automatic_response` is a per-resource concern and belongs in the service stack — not in this module.
-- The default `action` is `"count"` (observe only); set to `"none"` to let Shield block during an active attack.
-- Shield automatically adds the rule group to the ACL when first enabled. Always add the ARN to `var.shield_mitigation` before the next `terraform apply`, otherwise Terraform will remove the Shield rule group from the ACL.
-
-```hcl
-shield_mitigation = {
-  enabled        = true
-  rule_group_arn = "<arn-provided-by-shield>"
-  action         = "count" # change to "none" to enable blocking
-}
-```
-
-See the README for full details on finding the ARN and the recommended workflow.
 
 #### Configurable priorities for `everybody_else_config`, `blocked_headers`, `count_requests_from_ch`
 

--- a/README.md
+++ b/README.md
@@ -24,76 +24,12 @@ It's designed to propose the following rules:
 | defined in `var.country_rates[*].priority` | country_rates | Geographical rate limit rules, deployed as chunked rule groups (see below) |
 | `var.everybody_else_config.priority` (80) | everybody_else_config | Rate limit for all country codes not covered by `country_rates`. Set `limit = 0` to disable |
 | `var.country_count_rules_priority` (90) | country_count_rules | Rule group that counts requests from specific countries |
-| `var.shield_mitigation.priority` (10,000,000) | ShieldMitigationRuleGroup | AWS Shield Advanced automatic mitigation rule group (see below). Only deployed when `var.shield_mitigation.enabled = true` |
 
 ## Country rates — chunked rule groups
 
 The `country_rates` rules are deployed inside WAF rule groups rather than directly in the Web ACL. Because each WAF rule group has a fixed capacity, the module automatically splits `var.country_rates` into chunks of 4 and creates one rule group per chunk (`country_rate_rules_0`, `country_rate_rules_1`, …). This allows you to define an unlimited number of country rate rules without hitting WAF capacity limits.
 
 Each entry in `var.country_rates` maps to one rate-based rule inside the appropriate chunk group. The `priority` field is scoped to the rule group (not the Web ACL), so priorities only need to be unique within `var.country_rates` itself.
-
-## AWS Shield Advanced integration
-
-When [AWS Shield Advanced automatic application layer DDoS mitigation](https://docs.aws.amazon.com/waf/latest/developerguide/ddos-automatic-app-layer-response-rg.html) is enabled on a protected resource, Shield creates and manages a **single WAF rule group per Web ACL**. Even if multiple resources (e.g. multiple CloudFront distributions) share the same ACL and all have automatic mitigation enabled, Shield still creates only one rule group for that ACL. This module references that rule group via `var.shield_mitigation`:
-
-```hcl
-shield_mitigation = {
-  enabled        = true
-  rule_group_arn = "<arn-provided-by-shield>"  # available after Shield has created the group
-  priority       = 10000000                    # default — runs after all your own rules
-  action         = "count"                     # default — observe only; set to "none" to let Shield block
-}
-```
-
-- `rule_group_arn` is required when `enabled = true`; Shield creates it once automatic mitigation is activated on any resource associated with this ACL.
-- `action` controls the WAF `override_action` applied to the Shield rule group:
-  - `"count"` (default) — all requests are counted but never blocked by this rule group. Use this to observe Shield's detections without impact.
-  - `"none"` — the rule group's own actions apply, meaning Shield will block traffic it identifies as a DDoS attack. Switch to this when you are under active attack and have validated Shield's detections.
-- The default priority `10,000,000` is the value AWS itself assigns to Shield rules so they evaluate after all your own rules. Do not use this priority for any other rule.
-- If you have engaged the AWS Shield Response Team (SRT), they may add temporary rules at **low priority numbers** during an active DDoS event. Leave headroom at the low end of your priority range so the SRT has room to insert rules without conflicts.
-
-### Enabling automatic mitigation per resource
-
-`aws_shield_application_layer_automatic_response` is a **per-resource** Terraform resource — it must be declared for each CloudFront distribution or ALB you want to protect, in the stack that manages those resources (not in this module). This module only needs to know the resulting rule group ARN.
-
-```hcl
-# In your service/distribution stack — one per protected resource
-resource "aws_shield_application_layer_automatic_response" "this" {
-  resource_arn = aws_cloudfront_distribution.this.arn
-  action { count {} } # start with count; switch to block when confident
-}
-```
-
-### Finding the rule group ARN
-
-The ARN is only available after Shield has created the rule group. You can find it via:
-
-- **AWS Console** — Shield Advanced → Protected resources → select your resource → "Automatic application layer DDoS mitigation" section.
-- **AWS CLI:**
-  ```bash
-  aws wafv2 list-rule-groups --scope CLOUDFRONT --region us-east-1
-  ```
-  Look for a rule group named `ShieldMitigationRuleGroup_<account-id>_<web-acl-id>_<uuid>`.
-- **Terraform data source** — to avoid hardcoding the ARN:
-  ```hcl
-  data "aws_wafv2_rule_group" "shield" {
-    name  = "ShieldMitigationRuleGroup_<account-id>_<web-acl-id>_<uuid>"
-    scope = "CLOUDFRONT"
-  }
-
-  shield_mitigation = {
-    enabled        = true
-    rule_group_arn = data.aws_wafv2_rule_group.shield.arn
-  }
-  ```
-
-> **Important:** Shield automatically adds the rule group to your ACL when mitigation is first enabled. If you run `terraform apply` before declaring `shield_mitigation`, Terraform will remove the Shield rule group from the ACL. Always add the ARN to your config before the next apply.
-
-The typical workflow is:
-1. Declare `aws_shield_application_layer_automatic_response` for each protected resource in the service stack and apply.
-2. Shield creates the rule group and adds it to the ACL automatically.
-3. Retrieve the ARN (console, CLI, or data source) and add it to `var.shield_mitigation` in this module.
-4. Run `terraform apply` — Terraform now manages the rule group and will no longer remove it.
 
 ## Waf logging
 
@@ -285,7 +221,6 @@ No modules.
 | <a name="input_logo_path"></a> [logo\_path](#input\_logo\_path) | Company logo path (for 429 pages) | `string` | `""` | no |
 | <a name="input_logs_bucket_name_override"></a> [logs\_bucket\_name\_override](#input\_logs\_bucket\_name\_override) | Override the default bucket name for waf logs. Default name: `aws-waf-logs-<lower(var.waf_scope)>-<data.aws_caller_identity.current.account_id>` | `string` | `null` | no |
 | <a name="input_rate_limit_failsafe_priority"></a> [rate\_limit\_failsafe\_priority](#input\_rate\_limit\_failsafe\_priority) | Priority of the rate\_limit\_everything\_apart\_from\_CH failsafe rule in the WAF ACL. Must not conflict with any other rule priority. | `number` | `42` | no |
-| <a name="input_shield_mitigation"></a> [shield\_mitigation](#input\_shield\_mitigation) | Reference the Shield Advanced automatic mitigation rule group in the WAF ACL. AWS Shield Advanced creates and manages this rule group when automatic application layer DDoS mitigation is enabled on the protected resource — this variable lets you explicitly control its priority rather than letting Shield place it automatically. rule\_group\_arn must be provided when enabled; it is available after Shield has created the group. Priority defaults to 10,000,000, the value AWS assigns so that the Shield rule runs after all your own rules. Do not use priority 10,000,000 for any other rule. See https://docs.aws.amazon.com/waf/latest/developerguide/ddos-automatic-app-layer-response-rg.html | <pre>object({<br/>    enabled        = optional(bool, false)<br/>    priority       = optional(number, 10000000)<br/>    rule_group_arn = optional(string, null)<br/>    action         = optional(string, "count") # possible values: count (observe only), none (use rule group's own actions — blocks when Shield detects an attack)<br/>  })</pre> | `{}` | no |
 | <a name="input_waf_logs_retention"></a> [waf\_logs\_retention](#input\_waf\_logs\_retention) | Retention time (in days) of waf logs | `number` | `7` | no |
 | <a name="input_waf_name"></a> [waf\_name](#input\_waf\_name) | The name for WAF | `string` | `"cloudfront-waf"` | no |
 | <a name="input_waf_scope"></a> [waf\_scope](#input\_waf\_scope) | The scope of the deployed waf. Available options [CLOUDFRONT,REGIONAL] | `string` | `"CLOUDFRONT"` | no |

--- a/examples/complete/current/main.tf
+++ b/examples/complete/current/main.tf
@@ -13,6 +13,10 @@ terraform {
       source  = "hashicorp/aws"
       version = "~> 6.0"
     }
+    http = {
+      source  = "hashicorp/http"
+      version = "~> 3.0"
+    }
   }
 }
 
@@ -21,21 +25,36 @@ provider "aws" {
   alias  = "us"
 }
 
+module "googlebot_ips" {
+  source  = "tx-pts-dai/waf/aws//modules/ip_list_fetcher"
+  version = "~> 8.0"
+
+  url      = "https://developers.google.com/search/apis/ipranges/googlebot.json"
+  root_key = "prefixes"
+  ipv4_key = "ipv4Prefix"
+  ipv6_key = "ipv6Prefix"
+}
+
 locals {
-  google_whitelist_config = {
-    enable        = true
-    url           = "https://developers.google.com/search/apis/ipranges/googlebot.json"
-    insert_header = { "foo" = "bar" }
-  }
-  parsely_whitelist_config = { enable = false }
-  k6_whitelist_config      = { enable = false }
   ip_whitelisting = {
+    "googlebot_ipv4" = {
+      ips                = module.googlebot_ips.ipv4_addresses
+      ip_address_version = "IPV4"
+      priority           = 10
+      insert_header      = { "foo" = "bar" }
+    }
+    "googlebot_ipv6" = {
+      ips                = module.googlebot_ips.ipv6_addresses
+      ip_address_version = "IPV6"
+      priority           = 11
+      insert_header      = { "foo" = "bar" }
+    }
     "tx_group" = {
       ip_address_version = "IPV4"
       ips = [
         "120.0.0.0/32",
       ]
-      priority      = 11
+      priority      = 12
       insert_header = { "foo" = "bar" }
     }
     "tx_group_2" = {
@@ -43,7 +62,7 @@ locals {
       ips = [
         "120.0.1.0/32",
       ]
-      priority = 12
+      priority = 13
       insert_header = {
         "foo"           = "bar"
         "second_header" = "some_value"
@@ -54,38 +73,37 @@ locals {
       ips = [
         "120.0.2.0/32",
       ]
-      priority = 13
+      priority = 14
     }
     "tx_group_4" = {
       ip_address_version = "IPV6"
       ips = [
         "2001:db8::/32", # Example IPv6 range
       ]
-      priority = 14
+      priority = 15
     }
   }
 }
 
 module "waf" {
   source  = "tx-pts-dai/waf/aws"
-  version = "~> 7.0"
+  version = "~> 8.0"
   providers = {
     aws = aws.us
   }
-  waf_name                 = "waf-module-regression-example"
-  waf_scope                = "CLOUDFRONT"
-  waf_logs_retention       = 7
-  google_whitelist_config  = local.google_whitelist_config
-  parsely_whitelist_config = local.parsely_whitelist_config
-  k6_whitelist_config      = local.k6_whitelist_config
-  ip_whitelisting          = local.ip_whitelisting
-  blocked_headers = [
-    {
-      header            = "host"
-      value             = ".cloudfront.net"
-      string_match_type = "ENDS_WITH"
-    },
-  ]
+  waf_name           = "waf-module-regression-example"
+  waf_scope          = "CLOUDFRONT"
+  waf_logs_retention = 7
+  ip_whitelisting    = local.ip_whitelisting
+  blocked_headers = {
+    rules = [
+      {
+        header            = "host"
+        value             = ".cloudfront.net"
+        string_match_type = "ENDS_WITH"
+      },
+    ]
+  }
   whitelisted_headers = {
     headers = {
       "MyCustomHeader"  = "Lighthouse"
@@ -115,7 +133,7 @@ module "waf" {
       priority = 61
     }
   ]
-  count_requests_from_ch = false
+  count_requests_from_ch = { enabled = false }
   country_rates = [
     {
       name          = "Group_1-CH"
@@ -155,7 +173,7 @@ module "waf" {
     limit         = 100
     country_codes = ["CH"]
   }
-  everybody_else_limit      = 0
+  everybody_else_config     = { limit = 0 }
   block_uri_path_string     = []
   block_articles            = []
   block_regex_pattern       = {}
@@ -164,7 +182,7 @@ module "waf" {
 
 module "waf_parallel" {
   source  = "tx-pts-dai/waf/aws"
-  version = "~> 7.0"
+  version = "~> 8.0"
   providers = {
     aws = aws.us
   }
@@ -173,10 +191,7 @@ module "waf_parallel" {
   waf_scope          = "CLOUDFRONT"
   waf_logs_retention = 7
 
-  google_whitelist_config  = local.google_whitelist_config
-  parsely_whitelist_config = local.parsely_whitelist_config
-  k6_whitelist_config      = local.k6_whitelist_config
-  ip_whitelisting          = local.ip_whitelisting
+  ip_whitelisting = local.ip_whitelisting
   whitelisted_headers = {
     headers = {
       "MyCustomHeader"  = "Lighthouse"
@@ -206,7 +221,7 @@ module "waf_parallel" {
       priority = 61
     }
   ]
-  count_requests_from_ch = false
+  count_requests_from_ch = { enabled = false }
   country_rates = [
     {
       name          = "Group_1-CH"
@@ -242,7 +257,7 @@ module "waf_parallel" {
       priority      = 91
     }
   ]
-  everybody_else_limit = 0
+  everybody_else_config = { limit = 0 }
   limit_search_requests_by_countries = {
     limit         = 100
     country_codes = ["CH"]

--- a/variables.tf
+++ b/variables.tf
@@ -326,18 +326,3 @@ variable "country_count_rules_priority" {
   type        = number
   default     = 90
 }
-
-variable "shield_mitigation" {
-  description = "Reference the Shield Advanced automatic mitigation rule group in the WAF ACL. AWS Shield Advanced creates and manages this rule group when automatic application layer DDoS mitigation is enabled on the protected resource — this variable lets you explicitly control its priority rather than letting Shield place it automatically. rule_group_arn must be provided when enabled; it is available after Shield has created the group. Priority defaults to 10,000,000, the value AWS assigns so that the Shield rule runs after all your own rules. Do not use priority 10,000,000 for any other rule. See https://docs.aws.amazon.com/waf/latest/developerguide/ddos-automatic-app-layer-response-rg.html"
-  type = object({
-    enabled        = optional(bool, false)
-    priority       = optional(number, 10000000)
-    rule_group_arn = optional(string, null)
-    action         = optional(string, "count") # possible values: count (observe only), none (use rule group's own actions — blocks when Shield detects an attack)
-  })
-  default = {}
-  validation {
-    condition     = !var.shield_mitigation.enabled || var.shield_mitigation.rule_group_arn != null
-    error_message = "var.shield_mitigation.rule_group_arn must be set when shield_mitigation.enabled is true."
-  }
-}

--- a/waf.tf
+++ b/waf.tf
@@ -610,40 +610,6 @@ resource "aws_wafv2_web_acl" "waf" {
     }
   }
 
-  # Priority 10,000,000 is reserved for the AWS Shield Advanced automatic mitigation rule group.
-  # Do not assign this priority to any other rule.
-  #
-  # Additionally, if you have engaged the AWS Shield Response Team (SRT), they may add rules
-  # directly to this web ACL during an active DDoS event (with your approval). The SRT will
-  # typically place their rules at low priority numbers so they are evaluated before your own
-  # rules. Leave some headroom at the low end of your priority range for this purpose.
-  dynamic "rule" {
-    for_each = var.shield_mitigation.enabled ? [1] : []
-    content {
-      name     = "${var.waf_name}_ShieldMitigationRuleGroup"
-      priority = var.shield_mitigation.priority
-      override_action {
-        dynamic "count" {
-          for_each = var.shield_mitigation.action == "count" ? [1] : []
-          content {}
-        }
-        dynamic "none" {
-          for_each = var.shield_mitigation.action == "none" ? [1] : []
-          content {}
-        }
-      }
-      statement {
-        rule_group_reference_statement {
-          arn = var.shield_mitigation.rule_group_arn
-        }
-      }
-      visibility_config {
-        cloudwatch_metrics_enabled = true
-        metric_name                = "${var.waf_name}_ShieldMitigationRuleGroup"
-        sampled_requests_enabled   = true
-      }
-    }
-  }
 }
 
 resource "aws_wafv2_rule_group" "country_rate_rules" {


### PR DESCRIPTION
Removes the shield_mitigation variable, associated WAF rule block, and all Shield-related documentation from CHANGELOG and README.

Context: the rule is aws managed and enabled close to the shield protection enabling, in the cf repository. There's no need to declare it in the WAF module. No drift is detected